### PR TITLE
Change www.toggl.com to api.track.toggl.com

### DIFF
--- a/org-toggl.el
+++ b/org-toggl.el
@@ -42,7 +42,7 @@
   :type 'integer
   :group 'toggl)
 
-(defvar toggl-api-url "https://www.toggl.com/api/v8/"
+(defvar toggl-api-url "https://api.track.toggl.com/api/v8/"
   "The URL for making API calls.")
 
 (defun toggl-create-api-url (string)


### PR DESCRIPTION
`www.toggl.com` is deprecated (soon to be dropped) and is replaced by `api.track.toggl.com`

See here: https://github.com/toggl/toggl_api_docs

The package works fine with the above change.